### PR TITLE
chore: remove deploy script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "nuxt": "^3.11.2"
   },
   "devDependencies": {
+    "nuxthub": "^0.5.4",
     "@nuxt/eslint-config": "^0.2.0",
     "eslint": "^8.57.0",
     "vue-tsc": "^2.0.10",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "dev": "nuxt dev",
     "build": "nuxt build",
     "preview": "nuxt preview",
-    "deploy": "nuxthub deploy",
     "postinstall": "nuxt prepare",
     "lint": "eslint .",
     "typecheck": "nuxt typecheck"
@@ -16,7 +15,6 @@
     "nuxt": "^3.11.2"
   },
   "devDependencies": {
-    "nuxthub": "^0.5.4",
     "@nuxt/eslint-config": "^0.2.0",
     "eslint": "^8.57.0",
     "vue-tsc": "^2.0.10",


### PR DESCRIPTION
After I scaffold my application, if I try to run `npm run deploy` I get the following error:
```
nuxthub: not found
```

I think that the issue is that the `nuxthub` dependency is missing (or is the user supposed to have it installed globally before using the template?)