### PR TITLE
fix: correct typo in message.createdAt variable

### DIFF
--- a/app/components/MessagesPanel.vue
+++ b/app/components/MessagesPanel.vue
@@ -68,7 +68,7 @@ async function updateMessage(
         <i @click="deleteMessage(message.id)">delete</i>
       </button>
       -
-      {{ new Date(message.created_at || 0).toLocaleString("en") }}
+      {{ new Date(message.createdAt || 0).toLocaleString("en") }}
     </p>
     <p v-if="!messages?.length">
       No messages yet


### PR DESCRIPTION
Fixes a small typo in the starter template where message.created_at was used instead of message.createdAt